### PR TITLE
Test enhancement

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,13 @@ php:
   - 7.0
   - 7.1
   - 7.2
+  - nightly
 
-cache: 
+matrix:
+  allow_failures:
+    - php: nightly
+
+cache:
   apt: true
   bundler: true
 

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
     "ext-mbstring": "*"
   },
   "require-dev": {
-    "phpunit/phpunit": "^5.0"
+    "phpunit/phpunit": "^5.7 || ^6.5"
   },
   "license": "MIT",
   "authors": [
@@ -27,6 +27,11 @@
   "autoload": {
     "psr-4": {
       "TinyID\\": "src/TinyID"
+    }
+  },
+  "autoload-dev": {
+    "psr-4": {
+      "TinyID\\Tests\\Unit\\": "tests/Unit"
     }
   },
   "minimum-stability": "stable"

--- a/tests/Unit/TinyIDTest.php
+++ b/tests/Unit/TinyIDTest.php
@@ -73,29 +73,44 @@ class TinyIDTest extends TestCase
         self::assertEquals('18446744073709551615', $tinyId->decode($tinyId->encode('18446744073709551615')));
     }
 
+    public function failuresProvider()
+    {
+        return [
+            ['a', 'dictionary too short'],
+            ['aa', 'dictionary contains duplicated characters'],
+        ];
+    }
+
+    /**
+     * @test
+     * @dataProvider failuresProvider
+     */
+    public function failuresOnInvalidString($invalidString, $expectedMessage)
+    {
+        try {
+            new TinyID($invalidString);
+        } catch (\InvalidArgumentException $e) {
+            self::assertEquals($expectedMessage, $e->getMessage());
+        }
+    }
+
     /**
      * @test
      */
-    public function failures()
+    public function failuresOnEncodingWithNegativeNumber()
     {
-        try {
-            new TinyID('a');
-        } catch (\InvalidArgumentException $e) {
-            self::assertEquals('dictionary too short', $e->getMessage());
-        }
-
-        try {
-            new TinyID('aa');
-        } catch (\InvalidArgumentException $e) {
-            self::assertEquals('dictionary contains duplicated characters', $e->getMessage());
-        }
-
         try {
             (new TinyID('ab'))->encode(-1);
         } catch (\InvalidArgumentException $e) {
             self::assertEquals('cannot encode negative number', $e->getMessage());
         }
+    }
 
+    /**
+     * @test
+     */
+    public function failuresOnDecodingWithCharacter()
+    {
         try {
             (new TinyID('ab'))->decode('x');
         } catch (\InvalidArgumentException $e) {


### PR DESCRIPTION
# Changed log
- Let `failures` method split up into `failuresOnInvalidString`, `failuresOnEncodingWithNegativeNumber` and `failuresOnDecodingWithCharacter` methods because the original `failures` method does different test cases.
- Using the `dataProvider` to collect test cases for `failuresOnInvalidString` method.
- Set the different `PHPUnit` version to be compatible with multiple PHP versions.