### PR TITLE
Add casting integer type hint for $value string

### DIFF
--- a/src/TinyID/TinyID.php
+++ b/src/TinyID/TinyID.php
@@ -55,7 +55,7 @@ class TinyID
      */
     public function encode($value)
     {
-        if ($value < 0) {
+        if ((int) $value < 0) {
             throw new \InvalidArgumentException('cannot encode negative number');
         }
 


### PR DESCRIPTION
# Changed log
- Add the casting `integer` type hint for `$value` to do the numeric condition check.
- It's related to issue #2.